### PR TITLE
Feature: Implementing GET unpaid endpoint

### DIFF
--- a/controllers/unpaid/get/__tests__/unpaid.spec.js
+++ b/controllers/unpaid/get/__tests__/unpaid.spec.js
@@ -1,0 +1,39 @@
+
+const unpaidGet = require('../main');
+
+
+describe('unpaid get', ()=> {
+
+    it('can get unpaid payments', async()=>{
+
+        const failedPaymentStub = {
+            id: 1,
+            policy_reference: 'a51510ee-a123-4e7b-a67f-a6a6b601b3ab',
+            payment_id: 'a4036cfd-cc6b-4293-9ea5-f8ea1c63f23d',
+            amount: 15.00,
+            error_message: 'test failure',
+            status: 'failed',
+            error_code: 431,
+            created_at: '2022-02-02T18:37:39.665Z',
+            updated_at: '2022-02-02T18:37:39.665Z'
+          };
+
+        const policyRefs = ['0fbfb0f7-670a-4406-a654-1b81345289cf'];
+
+        const response = await unpaidGet({
+            policyReferences: policyRefs, 
+            fetchUnPaid: ()=> {
+                return failedPaymentStub;
+            }
+        });
+
+        expect(response[0]).toEqual(expect.objectContaining({
+            ...failedPaymentStub
+        }));
+
+
+        
+
+    });
+
+});

--- a/controllers/unpaid/get/index.js
+++ b/controllers/unpaid/get/index.js
@@ -3,9 +3,13 @@ const main = require('./main');
 
 module.exports = async (req, res) => {
 
-    main();
+    const policyReferenceFromQuery = req.query['policy_reference'];
 
-    res.status(500).send({msg: 'not yet implemented'});
+    const policyReferences = policyReferenceFromQuery.split(',');
+
+    const failedPayments = await main(policyReferences);
+
+    res.send(failedPayments);
 
 
 };

--- a/controllers/unpaid/get/main.js
+++ b/controllers/unpaid/get/main.js
@@ -1,6 +1,22 @@
+const {  fetchUnpaid : defaultFetchUnpaid } = require('../../../database/access/payments');
 
-module.exports = () => {
+module.exports = ({
+    policyReferences, 
+    fetchUnPaid = defaultFetchUnpaid
+    }) => {
 
+    let failedPayments = [];
+     
+    policyReferences.forEach((p)=>{
+        const failedPayment = fetchUnPaid(p);
+        if (failedPayment){
+            failedPayments.push(failedPayment);
+        }
+        
+    });
 
+    console.table(failedPayments);
+
+    return failedPayments;
 
 };

--- a/database/access/__tests__/payments.spec.js
+++ b/database/access/__tests__/payments.spec.js
@@ -1,6 +1,7 @@
-
 const { v4: uuidv4 } = require('uuid');
-const { savePayment } = require('../../access/payments');
+const { savePayment, fetchUnpaid } = require('../../access/payments');
+const dayjs = require('dayjs');
+const knex = require('../../index');
 
 
 describe('Making payments', ()=>{
@@ -32,3 +33,33 @@ describe('Making payments', ()=>{
     });
 });
 
+describe('Fetching failed payments', ()=>{
+
+    it('Can fetch failed payments', async () => {
+        
+        const failedPayment = {
+            policy_reference: uuidv4(),
+            payment_id: uuidv4(),
+            amount: 15.21,
+            status: 'failed',
+            error_message: 'test failure',
+            error_code: 431,
+            created_at: dayjs().toISOString(),
+            updated_at: dayjs().toISOString()
+        };
+
+        // insert fake failed payment
+        await knex('payments').insert(failedPayment);
+
+        // fetch failed payment
+        const failedPaymentResult = await fetchUnpaid(failedPayment.policy_reference);
+
+        // make assertion
+        expect(failedPaymentResult).toEqual(expect.objectContaining({
+            ...failedPayment, 
+            created_at: expect.anything(), 
+            updated_at: expect.anything() 
+        }));
+        
+    });
+});

--- a/database/access/payments.js
+++ b/database/access/payments.js
@@ -17,5 +17,25 @@ const savePayment = async ({payment, paymentId, status}) => {
 
 };
 
+const fetchUnpaid = async (policyReference) =>{
 
-module.exports = { savePayment };
+    console.log('fetching failed payments for:', policyReference);
+
+    const result = await knex('payments').where('policy_reference', policyReference);
+    
+    if (result.length > 0){
+        
+        console.log('failed payments exist for:', policyReference);
+
+        console.log(result[0]);
+        
+        return result[0];
+    }
+
+    console.log('no failed payments found', policyReference);
+    
+    return null;
+    
+};
+
+module.exports = { savePayment, fetchUnpaid };


### PR DESCRIPTION
**Implementation**

This PR implements a new endpoint `GET /unpaid`. 

This endpoint returns any failed payments that have occurred via the `POST /payments` action.

The endpoint can take a query string parameter of a comma seperated list of policy references.

**NOTE:** A `policy_reference` is a unique id that identifies a policy for a customer.

```
GET http://localhost:3232/unpaid?policy_reference=
```

Example: 
If I wanted to get any unpaid or failed payments for policys: `0d3cea30-652e-4a7d-a56e-131f87ee6175`, `da266b75-7ffb-4e45-bb5f-bcbe7ec63e47`. It would look like this:
```
GET http://localhost:3232/unpaid?policy_reference=0d3cea30-652e-4a7d-a56e-131f87ee6175,da266b75-7ffb-4e45-bb5f-bcbe7ec63e47
```

